### PR TITLE
Adds ignore prop for statusbar style

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,13 +24,14 @@ const TitleShape = {
 const StatusBarShape = {
   style: PropTypes.oneOf(['light-content', 'default', ]),
   hidden: PropTypes.bool,
+  ignore: PropTypes.bool,
   tintColor: PropTypes.string,
   hideAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ]),
   showAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ])
 };
 
 function customizeStatusBar(data) {
-  if (Platform.OS === 'ios') {
+  if (Platform.OS === 'ios' && !data.ignore) {
     if (data.style) {
       StatusBar.setBarStyle(data.style);
     }
@@ -130,6 +131,7 @@ class NavigationBar extends Component {
     statusBar: {
       style: 'default',
       hidden: false,
+      ignore: false,
       hideAnimation: 'slide',
       showAnimation: 'slide',
     },


### PR DESCRIPTION
Added to be able to use react-native-navbar and style/change the statusbar from other parts of the app.
## Case

I want `react-native-navbar` but want to change the statusbar color based on the background color of the navbar. I could use `react-native-navbar` for this but the problem is when swiping back. Then the statusbar color not changes back. To fix this the simples way is for me to style the statusbar by my self in the renderScene function of `react-native/navigator`. thats way i added a option to ignore styling of the statusbar in this package
