### PR TITLE
Added ability to specify title style property

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ That's it, you're ready to go!
   - **handler** - (Function) - onPress function handler
 - **title** - (Object, React Element) - Either plain object with configuration, or React Element which will be used as a custom title element. Configuration object has following keys:
   - **title** - (String) - Button's title
+  - **style** - (Object, Array, Number) - Style object or array of style objects
   - **tintColor** - (String) - Title's text color
 
 ### Usage with Webpack

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const ButtonShape = {
 
 const TitleShape = {
   title: PropTypes.string.isRequired,
+  style: PropTypes.oneOfTypes([PropTypes.object, PropTypes.array,PropTypes.number]),
   tintColor: PropTypes.string,
 };
 
@@ -72,11 +73,12 @@ class NavigationBar extends Component {
     }
 
     const colorStyle = data.tintColor ? { color: data.tintColor, } : null;
+    const style = data.style ? data.style : styles.navBarTitleText;
 
     return (
       <View style={styles.navBarTitleContainer}>
         <Text
-          style={[styles.navBarTitleText, colorStyle, ]}>
+          style={[style, colorStyle, ]}>
           {data.title}
         </Text>
       </View>


### PR DESCRIPTION
This allows the user to simply pass in a title style to replace the default `navBarTitleText`.

I am aware that they are able to specify a custom element, but I think that its convenient to imply let them specify the tile and not necessarily require them to create a new component.

This is also more consistent with how styles are defined for buttons.

