### PR TITLE
Style change of status bar was lagging

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class NavigationBar extends Component {
   }
 
   componentWillReceiveProps(props) {
-    customizeStatusBar(this.props.statusBar);
+    customizeStatusBar(props.statusBar);
   }
 
   getButtonElement(data = {}, style) {

--- a/index.js
+++ b/index.js
@@ -25,21 +25,26 @@ const StatusBarShape = {
   style: PropTypes.oneOf(['light-content', 'default', ]),
   hidden: PropTypes.bool,
   tintColor: PropTypes.string,
+  animated: PropTypes.bool, // affects `style` and `hidden`
   hideAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ]),
   showAnimation: PropTypes.oneOf(['fade', 'slide', 'none', ])
 };
 
 function customizeStatusBar(data) {
   if (Platform.OS === 'ios') {
+    const animated = (data.animated || NavigationBar.defaultProps.statusBar.animated)
     if (data.style) {
-      StatusBar.setBarStyle(data.style);
+      StatusBar.setBarStyle(data.style, animated);
     }
-    const animation = data.hidden ?
-    (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
-    (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);
-
-    StatusBar.showHideTransition = animation;
-    StatusBar.hidden = data.hidden;
+    if (data.hidden !== undefined) {
+      let showHideTransition = 'none';
+      if (animated) {
+        showHideTransition = data.hidden ?
+          (data.hideAnimation || NavigationBar.defaultProps.statusBar.hideAnimation) :
+          (data.showAnimation || NavigationBar.defaultProps.statusBar.showAnimation);
+      }
+      StatusBar.setHidden(data.hidden, showHideTransition);
+    }
   }
 }
 
@@ -130,6 +135,7 @@ class NavigationBar extends Component {
     statusBar: {
       style: 'default',
       hidden: false,
+      animated: false,
       hideAnimation: 'slide',
       showAnimation: 'slide',
     },


### PR DESCRIPTION
Because the imperative status bar interface was pulling from the old props instead of incoming props when the component was updated, the status bar style was not getting updated until the next change came in, resulting in the status bar style and navbar styles being out of sync.

Note that this PR includes the changes from @mosesoak PR #159 which has not yet been merged, though it has been over 4 months (@kureev is this component no longer being actively maintained?)