### PR TITLE
Enable status bar space for android

### DIFF
--- a/index.js
+++ b/index.js
@@ -97,10 +97,8 @@ class NavigationBar extends Component {
 
     let statusBar = null;
 
-    if (Platform.OS === 'ios') {
-      statusBar = !this.props.statusBar.hidden ?
-        <View style={[styles.statusBar, customStatusBarTintColor ]} /> : null;
-    }
+    statusBar = !this.props.statusBar.hidden ?
+      <View style={[styles.statusBar, customStatusBarTintColor ]} /> : null;
 
     return (
       <View style={[styles.navBarContainer, customTintColor, ]}>

--- a/index.js
+++ b/index.js
@@ -93,10 +93,8 @@ class NavigationBar extends Component {
 
     let statusBar = null;
 
-    if (Platform.OS === 'ios') {
-      statusBar = !this.props.statusBar.hidden ?
-        <View style={[styles.statusBar, customStatusBarTintColor, ]} /> : null;
-    }
+    statusBar = !this.props.statusBar.hidden ?
+      <View style={[styles.statusBar, customStatusBarTintColor, ]} /> : null;
 
     return (
       <View style={[styles.navBarContainer, containerStyle, customTintColor, ]}>


### PR DESCRIPTION
I think that the AppBar should add the statusBar space in both platforms (as long as the status bar is not hidden)
This way the statusBar will have the same color as the content of the screen.

Let me know what you think.

Thanks,
David
