### PR TITLE
change navbar to Animated.View to allow for extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ import {
   StatusBar,
   Text,
   View,
-  Platform
+  Platform,
+  Animated
 } from 'react-native';
 
 import NavbarButton from './NavbarButton';
@@ -107,11 +108,11 @@ class NavigationBar extends Component {
     return (
       <View style={[styles.navBarContainer, customTintColor, ]}>
         {statusBar}
-        <View style={[styles.navBar, this.props.style, ]}>
+        <Animated.View style={[styles.navBar, this.props.style, ]}>
           {this.getTitleElement(this.props.title)}
           {this.getButtonElement(this.props.leftButton, { marginLeft: 8, })}
           {this.getButtonElement(this.props.rightButton, { marginRight: 8, })}
-        </View>
+        </Animated.View>
       </View>
     );
   }


### PR DESCRIPTION
In many circumstances we want to add animations to a navBar transition. For example, when we scroll up / down in a `ScrollView`, we want to hide / show navBar. 

This PR exposes the navBar portion of the view as an `Animated.View` so that animation can be applied on this view through `this.props.style`