### PR TITLE
Allow accessibility label for navbar button

### DIFF
--- a/NavbarButton.js
+++ b/NavbarButton.js
@@ -15,6 +15,8 @@ export default function NavbarButton(props) {
       style={styles.navBarButton}
       onPress={handler}
       disabled={disabled}
+      accessible={accessible}
+      accessibilityLabel={accessibilityLabel}
     >
       <View style={style}>
         <Text style={[styles.navBarButtonText, { color: tintColor }]}>{title}</Text>
@@ -32,6 +34,8 @@ NavbarButton.propTypes = {
   title: PropTypes.string,
   handler: PropTypes.func,
   disabled: PropTypes.bool,
+  accessible: PropTypes.bool,
+  accessibilityLabel: PropTypes.string,
 };
 
 NavbarButton.defaultProps = {

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ That's it, you're ready to go!
   - **style** - (Object, Array) - Style object or array of style objects
   - **handler** - (Function) - onPress function handler
   - **disabled** - (Boolean) - If true, disable interactions for this button.
+  - **accessible** - (Boolean) - Indicates that the view is an accessibility element
+  - **accessibilityLabel** - (String, React Element) - Overrides the text that's read by the screen reader for the button.
 - **title** - (Object, React Element) - Either plain object with configuration, or React Element which will be used as a custom title element. Configuration object has following keys:
   - **title** - (String) - Button's title
   - **style** - (Object, Array, Number) - Style object or array of style objects

--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ function getButtonElement(data, style) {
           style={[data.style, style]}
           tintColor={data.tintColor}
           handler={data.handler}
+          accessible={data.accessible}
+          accessibilityLabel={data.accessibilityLabel}
         />
       )}
     </View>


### PR DESCRIPTION
Allow consumer to set the `accessible` and `accessibilityLabel`property through the button configs.