### PR TITLE
Fix 'accessible is not defined' issue

### DIFF
--- a/NavbarButton.js
+++ b/NavbarButton.js
@@ -8,7 +8,7 @@ import {
 import styles from './styles';
 
 export default function NavbarButton(props) {
-  const { style, tintColor, title, handler, disabled } = props;
+  const { style, tintColor, title, handler, disabled, accessible, accessibilityLabel } = props;
 
   return (
     <TouchableOpacity


### PR DESCRIPTION
I got an error 'accessible is not defined' issue from NavbarButton.

`accessible` and `accessibilityLabel` were not destructure from `props`.

