### PR TITLE
Gracefully deprecate ViewPropTypes

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,7 +66,7 @@ function getTitleElement(data) {
 
 export default class NavigationBar extends Component {
   static propTypes = {
-    style: View.propTypes.style,
+    style: ViewPropTypes.style,
     tintColor: PropTypes.string,
     statusBar: PropTypes.shape(StatusBarShape),
     leftButton: PropTypes.oneOfType([

--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ import {
   Text,
   View,
   Platform,
-  ViewPropTypes,
 } from 'react-native';
-import PropTypes from 'prop-types'
+import PropTypes from 'prop-types';
+import ViewPropTypes from './lib';
 
 import NavbarButton from './NavbarButton';
 import styles from './styles';

--- a/lib.js
+++ b/lib.js
@@ -1,0 +1,5 @@
+import { View, ViewPropTypes as RNViewPropTypes } from 'react-native';
+
+const ViewPropTypes = RNViewPropTypes || View.propTypes;
+
+export default ViewPropTypes;


### PR DESCRIPTION
Recently the transition was made from View.propTypes to ViewPropTypes. 

However, `ViewPropTypes` is only available in react-native@0.44, so all those who are using older versions of react-native are seeing bugs. 

This PR *gracefully* deprecates `View.propTypes` by using:
* `View.propTypes` for those using react-native@0.43 and lower
* `ViewPropTypes` for those using react-native@0.44 and higher.

This allows those using older versions to still use the latest version of your library.

References #231 