### PR TITLE
Add support to ellipsizeMode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 **/xcuserdata
 .DS_Store
 **/.DS_Store
+**/*.swp

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ That's it, you're ready to go!
   - **title** - (String) - Button's title
   - **style** - (Object, Array, Number) - Style object or array of style objects
   - **tintColor** - (String) - Title's text color
+  - **ellipsizeMode** - ('head', 'middle', 'tail', 'clip') - How to [display](https://facebook.github.io/react-native/docs/text.html#ellipsizemode) the text
+  - **numberOfLines** - (Number) - How to [truncate](https://facebook.github.io/react-native/docs/text.html#numberoflines) the text
 
 ### Usage with Webpack
 This module uses JSX syntax and requires a compiler such as [babel](https://babeljs.io/).

--- a/index.js
+++ b/index.js
@@ -21,6 +21,8 @@ const ButtonShape = {
 const TitleShape = {
   title: PropTypes.string.isRequired,
   tintColor: PropTypes.string,
+  ellipsizeMode: PropTypes.string,
+  numberOfLines: PropTypes.number
 };
 
 const StatusBarShape = {
@@ -57,7 +59,7 @@ function getTitleElement(data) {
 
   return (
     <View style={styles.navBarTitleContainer}>
-      <Text style={[styles.navBarTitleText, data.style, colorStyle]}>
+      <Text ellipsizeMode={data.ellipsizeMode} numberOfLines={data.numberOfLines} style={[styles.navBarTitleText, data.style, colorStyle]}>
         {data.title}
       </Text>
     </View>


### PR DESCRIPTION
This PR adds support to ellipsizeMode. Doing so, the beginning fits in the container and the missing text at the end of the line is indicated by an ellipsis glyph. e.g., "abcd...". For further details, please take a look at React Native documentation [here](https://facebook.github.io/react-native/docs/text.html#ellipsizemode). Thanks.

See an example below 👇 

<img width="402" alt="screen shot 2017-10-29 at 22 38 27" src="https://user-images.githubusercontent.com/1886786/32150607-4ac3bc06-bcfc-11e7-83bf-413ba09bdde8.png">
