### PR TITLE
Add option to remove and not manage status bar completely

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ That's it, you're ready to go!
 - **style** - (Object, Array) - Style object or array of style objects
 - **containerStyle** - (Object) - Style object for styling navbar container
 - **tintColor** - (String) - NavigationBar's tint color
-- **statusBar** - (Object):
+- **statusBar** - (Object, null):
   - **style** - ('light-content' or 'default') - Style of statusBar
   - **hidden** - (Boolean)
   - **tintColor** - (String) - Status bar tint color

--- a/index.js
+++ b/index.js
@@ -70,7 +70,10 @@ export default class NavigationBar extends Component {
   static propTypes = {
     style: ViewPropTypes.style,
     tintColor: PropTypes.string,
-    statusBar: PropTypes.shape(StatusBarShape),
+    statusBar: PropTypes.oneOfType([
+      PropTypes.shape(StatusBarShape),
+      PropTypes.oneOf([null, false]),
+    ]),
     leftButton: PropTypes.oneOfType([
       PropTypes.shape(ButtonShape),
       PropTypes.element,
@@ -114,7 +117,7 @@ export default class NavigationBar extends Component {
 
   customizeStatusBar() {
     const { statusBar } = this.props;
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === 'ios' && statusBar) {
       if (statusBar.style) {
         StatusBar.setBarStyle(statusBar.style);
       }
@@ -138,14 +141,14 @@ export default class NavigationBar extends Component {
     } = this.props;
     const customTintColor = tintColor ? { backgroundColor: tintColor } : null;
 
-    const customStatusBarTintColor = this.props.statusBar.tintColor ?
-      { backgroundColor: this.props.statusBar.tintColor } : null;
-
     let statusBar = null;
 
-    if (Platform.OS === 'ios') {
+    if (Platform.OS === 'ios' && this.props.statusBar) {
       statusBar = !this.props.statusBar.hidden ?
-        <View style={[styles.statusBar, customStatusBarTintColor]} /> : null;
+        <View style={[
+          styles.statusBar,
+          this.props.statusBar.tintColor ? { backgroundColor: this.props.statusBar.tintColor } : null
+        ]} /> : null;
     }
 
     return (


### PR DESCRIPTION
It may be useful using SafeAreaView or when managing status bar manually.