### PR TITLE
BugFix : Enable to make disable Left/Right button

### DIFF
--- a/NavbarButton.js
+++ b/NavbarButton.js
@@ -26,6 +26,7 @@ export default function NavbarButton(props) {
       disabled={disabled}
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
+      style={disabled ? { opacity: 0.4 } : {}}
     >
       <View style={style}>
         <Text style={[styles.navBarButtonText, { color: tintColor }]}>{title}</Text>

--- a/NavbarButton.js
+++ b/NavbarButton.js
@@ -18,6 +18,7 @@ export default function NavbarButton(props) {
     accessible,
     accessibilityLabel
   } = props;
+  const disabledStyle = disabled ? { opacity: 0.6 } : {};
 
   return (
     <TouchableOpacity
@@ -26,10 +27,9 @@ export default function NavbarButton(props) {
       disabled={disabled}
       accessible={accessible}
       accessibilityLabel={accessibilityLabel}
-      style={disabled ? { opacity: 0.4 } : {}}
     >
       <View style={style}>
-        <Text style={[styles.navBarButtonText, { color: tintColor }]}>{title}</Text>
+        <Text style={[styles.navBarButtonText, { color: tintColor }, disabledStyle]}>{title}</Text>
       </View>
     </TouchableOpacity>
   );

--- a/index.js
+++ b/index.js
@@ -42,6 +42,7 @@ function getButtonElement(data, style) {
           style={[data.style, style]}
           tintColor={data.tintColor}
           handler={data.handler}
+          disabled={data.disabled}
           accessible={data.accessible}
           accessibilityLabel={data.accessibilityLabel}
         />


### PR DESCRIPTION
In `getButtonElement` function, `NavbarButton` component disabled prop was omitted.
Because of this bug, developer can't make button disabled.

Put disabled prop and passing `data.disabled` argument to `NavbarButton` component, now can make it disabled :)