### PR TITLE
docs: update documentation links to reactnative.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ That's it, you're ready to go!
   - **title** - (String) - Button's title
   - **style** - (Object, Array, Number) - Style object or array of style objects
   - **tintColor** - (String) - Title's text color
-  - **ellipsizeMode** - ('head', 'middle', 'tail', 'clip') - How to [display](https://facebook.github.io/react-native/docs/text.html#ellipsizemode) the text
-  - **numberOfLines** - (Number) - How to [truncate](https://facebook.github.io/react-native/docs/text.html#numberoflines) the text
+  - **ellipsizeMode** - ('head', 'middle', 'tail', 'clip') - How to [display](https://reactnative.dev/docs/text.html#ellipsizemode) the text
+  - **numberOfLines** - (Number) - How to [truncate](https://reactnative.dev/docs/text.html#numberoflines) the text
 
 ### Usage with Webpack
 This module uses JSX syntax and requires a compiler such as [babel](https://babeljs.io/).

--- a/examples/Basic/ios/main.jsbundle
+++ b/examples/Basic/ios/main.jsbundle
@@ -3,6 +3,6 @@
 //
 // $ react-native bundle --minify
 //
-// See http://facebook.github.io/react-native/docs/runningondevice.html for more details.
+// See https://reactnative.dev/docs/runningondevice.html for more details.
 
 throw new Error('Offline JS file is empty. See iOS/main.jsbundle for instructions');

--- a/examples/CustomElements/ios/main.jsbundle
+++ b/examples/CustomElements/ios/main.jsbundle
@@ -3,6 +3,6 @@
 //
 // $ react-native bundle --minify
 //
-// See http://facebook.github.io/react-native/docs/runningondevice.html for more details.
+// See https://reactnative.dev/docs/runningondevice.html for more details.
 
 throw new Error('Offline JS file is empty. See iOS/main.jsbundle for instructions');

--- a/examples/Routing/ios/main.jsbundle
+++ b/examples/Routing/ios/main.jsbundle
@@ -3,6 +3,6 @@
 //
 // $ react-native bundle --minify
 //
-// See http://facebook.github.io/react-native/docs/runningondevice.html for more details.
+// See https://reactnative.dev/docs/runningondevice.html for more details.
 
 throw new Error('Offline JS file is empty. See iOS/main.jsbundle for instructions');


### PR DESCRIPTION
# Summary
This PR update react native docs links to new domain: reactnative.dev

## Test Plan
Open links in changed files